### PR TITLE
Update adservice image to maestrops/adservice:2-ae7ef5b

### DIFF
--- a/manifests/adservice.yml
+++ b/manifests/adservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/adservice:v0.2.3
+        image: maestrops/adservice:2-ae7ef5b
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
This pull request updates the adservice image tag to `maestrops/adservice:2-ae7ef5b`.
Please review and merge to deploy the updated image to the cluster.