### PR TITLE
Update adservice image to maestrops/adservice:

### DIFF
--- a/manifests/adservice.yml
+++ b/manifests/adservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: maestrops/adservice:2-ae7ef5b
+        image: maestrops/adservice:
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
This pull request updates the adservice image tag to `maestrops/adservice:`.
Please review and merge to deploy the updated image to the cluster.