### PR TITLE
Update adservice image to maestrops/adservice:9-df3ca9d

### DIFF
--- a/manifests/adservice.yml
+++ b/manifests/adservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: maestrops/adservice:2-ae7ef5b
+        image: maestrops/adservice:9-df3ca9d
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
This pull request updates the adservice image tag to `maestrops/adservice:9-df3ca9d`.
Please review and merge to deploy the updated image to the cluster.