### PR TITLE
Update cartservice image to maestrops/cartservice:

### DIFF
--- a/manifests/cartservice.yml
+++ b/manifests/cartservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/cartservice:v0.2.3
+        image: maestrops/cartservice:
         ports:
         - containerPort: 7070
         env:
@@ -64,7 +64,7 @@ spec:
     spec:
       containers:
       - name: redis
-        image: redis:alpine
+        image: maestrops/cartservice:
         ports:
         - containerPort: 6379
         readinessProbe:


### PR DESCRIPTION
This pull request updates the cartservice image tag to `maestrops/cartservice:`.
Please review and merge to deploy the updated image to the cluster.