### PR TITLE
Update adservice image to maestrops/adservice:10-666ecff

### DIFF
--- a/manifests/adservice.yml
+++ b/manifests/adservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: maestrops/adservice:9-df3ca9d
+        image: maestrops/adservice:10-666ecff
         ports:
         - containerPort: 9555
         env:


### PR DESCRIPTION
This pull request updates the adservice image tag to `maestrops/adservice:10-666ecff`.
Please review and merge to deploy the updated image to the cluster.