### PR TITLE
Update checkoutservice image to maestrops/checkoutservice:3-7df2473

### DIFF
--- a/manifests/checkoutservice.yml
+++ b/manifests/checkoutservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/checkoutservice:v0.2.3
+          image: maestrops/checkoutservice:3-7df2473
           ports:
           - containerPort: 5050
           readinessProbe:


### PR DESCRIPTION
This pull request updates the checkoutservice image tag to `maestrops/checkoutservice:3-7df2473`.
Please review and merge to deploy the updated image to the cluster.