### PR TITLE
Update currencyservice image to maestrops/currencyservice:3-7df2473

### DIFF
--- a/manifests/currencyservice.yml
+++ b/manifests/currencyservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/currencyservice:v0.2.3
+        image: maestrops/currencyservice:3-7df2473
         ports:
         - containerPort: 7000
         env:


### PR DESCRIPTION
This pull request updates the currencyservice image tag to `maestrops/currencyservice:3-7df2473`.
Please review and merge to deploy the updated image to the cluster.