### PR TITLE
Update emailservice image to maestrops/emailservice:3-7df2473

### DIFF
--- a/manifests/emailservice.yml
+++ b/manifests/emailservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/emailservice:v0.2.3
+        image: maestrops/emailservice:3-7df2473
         ports:
         - containerPort: 8080
         env:


### PR DESCRIPTION
This pull request updates the emailservice image tag to `maestrops/emailservice:3-7df2473`.
Please review and merge to deploy the updated image to the cluster.