### PR TITLE
Update frontend image to maestrops/cymbal-frontend:6-7df2473

### DIFF
--- a/manifests/frontend.yml
+++ b/manifests/frontend.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: server
-          image: gcr.io/google-samples/microservices-demo/frontend:v0.2.3
+          image: maestrops/cymbal-frontend:6-7df2473
           ports:
           - containerPort: 8080
           readinessProbe:


### PR DESCRIPTION
This pull request updates the frontend image tag to `maestrops/cymbal-frontend:6-7df2473`.
Please review and merge to deploy the updated image to the cluster.