### PR TITLE
Update paymentservice image to maestrops/paymentservice:2-7df2473

### DIFF
--- a/manifests/paymentservice.yml
+++ b/manifests/paymentservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/paymentservice:v0.2.3
+        image: maestrops/paymentservice:2-7df2473
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
This pull request updates the paymentservice image tag to `maestrops/paymentservice:2-7df2473`.
Please review and merge to deploy the updated image to the cluster.