### PR TITLE
Update productcatalogservice image to maestrops/productcatalogservice:2-7df2473

### DIFF
--- a/manifests/productcatalogservice.yml
+++ b/manifests/productcatalogservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/productcatalogservice:v0.2.3
+        image: maestrops/productcatalogservice:2-7df2473
         ports:
         - containerPort: 3550
         env:


### PR DESCRIPTION
This pull request updates the productcatalogservice image tag to `maestrops/productcatalogservice:2-7df2473`.
Please review and merge to deploy the updated image to the cluster.