### PR TITLE
Update recommendationservice image to maestrops/recommendationservice:2-7df2473

### DIFF
--- a/manifests/recommendationservice.yml
+++ b/manifests/recommendationservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/recommendationservice:v0.2.3
+        image: maestrops/recommendationservice:2-7df2473
         ports:
         - containerPort: 8080
         readinessProbe:


### PR DESCRIPTION
This pull request updates the recommendationservice image tag to `maestrops/recommendationservice:2-7df2473`.
Please review and merge to deploy the updated image to the cluster.