### PR TITLE
Update shippingservice image to maestrops/shippingservice:2-7df2473

### DIFF
--- a/manifests/shippingservice.yml
+++ b/manifests/shippingservice.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
       - name: server
-        image: gcr.io/google-samples/microservices-demo/shippingservice:v0.2.3
+        image: maestrops/shippingservice:2-7df2473
         ports:
         - containerPort: 50051
         env:


### PR DESCRIPTION
This pull request updates the shippingservice image tag to `maestrops/shippingservice:2-7df2473`.
Please review and merge to deploy the updated image to the cluster.